### PR TITLE
Aggiunta dei CDATA

### DIFF
--- a/fatturapa.php
+++ b/fatturapa.php
@@ -24,6 +24,14 @@ class FatturaPA {
 	}
 	
 	/**
+	 * Ritorna la stringa all'interno del tag CDATA. Migliore alternativa ad htmlentities in quanto non altera il testo.
+	 * @param string $string (default: "" = stringa vuota)
+	 */
+	public function add_cdata($string = ""){
+		return "<![CDATA[".$string."]]>";
+	}
+	
+	/**
 	 * Imposta dati trasmittente (es.: azienda o commercialista) (opzionale: copia dati mittente)
 	 * @param array $data
 	 */
@@ -571,7 +579,11 @@ class FatturaPA {
 					}
 					else	// è un nodo finale: qui ho il valore
 					{
-						$xml .= htmlspecialchars($sub);
+						if (strpos($sub, '<![CDATA[') !== false) {
+							$xml .= $sub;
+						}else{
+							$xml .= htmlspecialchars($sub);
+						}
 						
 					}
 					$xml .= "</{$name}>"."\n";


### PR DESCRIPTION
Dato che htmlentities altera fortemente il contenuto del documento, ho pensato di aggiungere un metodo "add_cdata" che permetta di poter usare il tag <![CDATA[]]> anziché l'htmlentities di php.

Esempio:
$fatturapa->set_destinatario([
  // Dati cliente destinatario fattura
  'ragsoc' => $fatturapa->add_cdata("Il Mio Cliente Spa"),
  'indirizzo' => $fatturapa->add_cdata("Via Roma 24"),
  'cap' => "20121",
  'comune' => "Milano",
  'prov' => "MI",
  'paese' => "IT",
  'piva' => "12345678901",
  //'codfisc' => "CODFSC23A45H671U",
  // Dati SdI (Sistema di Interscambio) del destinatario/cliente
  'sdi_codice' => "1234567",    // Codice destinatario - da impostare in alternativa alla PEC
  'sdi_pec' => "pec@test.com",  // PEC destinatario - da impostare in alternativa al Codice		
]);

Affinché tutto funzioni correttamente, ho alterano la linea 580 in modo tale che se è già presente un campo CDATA, non venga eseguito l'htmlentities.